### PR TITLE
Adds environment configuration files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Supabase Configuration
+EXPO_PUBLIC_SUPABASE_URL=your-supabase-project-url
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+DATABASE_URL=your-postgres-connection-string
+
+# Apple Wallet Configuration
+APPLE_WALLET_TEAM_ID=your-apple-team-id
+APPLE_WALLET_PASS_TYPE_ID=your-pass-type-identifier
+
+# Google Wallet Configuration
+GOOGLE_WALLET_SERVICE_ACCOUNT_EMAIL=your-service-account-email
+GOOGLE_WALLET_PRIVATE_KEY=your-private-key
+GOOGLE_WALLET_ISSUER_ID=your-issuer-id

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.*
 
 # local env files
 .env*.local
+.env.local*
 
 # typescript
 *.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "env:local": "cp .env.local.local_settings .env.local && echo 'Switched to local development environment'",
+    "env:remote": "cp .env.local.remote_settings .env.local && echo 'Switched to remote development environment'"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
Introduces `.env.example` for documenting environment variables.

Adds scripts for switching between local and remote `.env.local` settings.

Ignores `.env.local*` files to prevent accidental commits of environment-specific configurations.
